### PR TITLE
removing `unique=True` constraint on `password`

### DIFF
--- a/autotradeweb/server.py
+++ b/autotradeweb/server.py
@@ -114,7 +114,7 @@ class stock_prediction(db.Model):
 class User(db.Model):
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
     username = db.Column(db.String(80), index=True, unique=True, nullable=False)
-    password = db.Column(db.String(80), index=True, unique=True, nullable=False)
+    password = db.Column(db.String(80), index=True, nullable=False)
     bank = db.Column(db.Float(), default=0.0, nullable=False)
 
     def to_dict(self):


### PR DESCRIPTION
This was a security issue as it can potentially leak other users password by having a attacker register a new account with same password as the victim's password. A resultant error from the unique column clause on `password` would then allow a attacker know that such password exists within the service.

Removing the `unique=True` clause from `autotradeweb` and its supporting databases removes this attack.