### PR TITLE
`trading_session.start_time` use UTC timezone

### DIFF
--- a/autotradeweb/server.py
+++ b/autotradeweb/server.py
@@ -295,7 +295,7 @@ def on_click(n_clicks, stock_id):
         __log__.debug(f"adding trading session for stock {stock_id}")
         new_trading_session_db = trading_session(
             username=username,
-            start_time=datetime.now(),
+            start_time=datetime.utcnow(),
             end_time=None,
             ticker=stock_id,
             is_paused=False,

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -286,7 +286,7 @@ class TestDatabaseBindings:
 
     def test_add_trading_session(self):
         trading_session_ = trading_session(
-            username="foo", ticker="bar", start_time=datetime.now()
+            username="foo", ticker="bar", start_time=datetime.utcnow()
         )
         db.session.add(trading_session_)
         db.session.commit()


### PR DESCRIPTION
Using UTC timezone for `trading_session.start_time` to be consistent.